### PR TITLE
Using the modern and safer way to copy text to clipboard

### DIFF
--- a/components/mdx/CodeBlock.tsx
+++ b/components/mdx/CodeBlock.tsx
@@ -22,7 +22,7 @@ export function CodeBlock({ children, ...props }: CodeBlockProps) {
     perspective: '500px',
   }
 
-  function copyToClipboard() {
+  async function copyToClipboard() {
     setIsCopied(true)
     setTimeout(() => setIsCopied(false), 2000)
 
@@ -38,9 +38,8 @@ export function CodeBlock({ children, ...props }: CodeBlockProps) {
       textareaEl.style.visibility = 'none'
       document.body.appendChild(textareaEl)
 
-      // select and copy
-      textareaEl.select()
-      document.execCommand('copy')
+      // copy code
+      await navigator.clipboard.writeText(textareaEl.value)
 
       // cleanup
       document.body.removeChild(textareaEl)


### PR DESCRIPTION
I replaced `document.execCommand()` with the Clipboard API for copying the text.
It's the modern and safer way to copy text.

[Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText)

[execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand)

![image](https://user-images.githubusercontent.com/51731966/123067957-15400280-d42f-11eb-94ab-885be8fbbb01.png)
