### PR TITLE
fix: Typo in selecting element

### DIFF
--- a/posts/how-to-think-like-a-developer.mdx
+++ b/posts/how-to-think-like-a-developer.mdx
@@ -99,7 +99,7 @@ You'll often find great [Stack Overflow](https://stackoverflow.com/) threads. Th
 Select the input element:
 
 ```js:app.js
-const inputEl = document.querySelector('[data-add]')
+const inputEl = document.querySelector('[data-input]')
 ```
 
 ```js:example.js


### PR DESCRIPTION
The input element has the `data-input` attribute and in JS you were selecting it with the `data-add` attribute.