### PR TITLE
Fix :bug:: Fixed styling for SVELTE events tutorial

### DIFF
--- a/posts/svelte-for-beginners/svelte-for-beginners.md
+++ b/posts/svelte-for-beginners/svelte-for-beginners.md
@@ -501,7 +501,7 @@ In Svelte you use the `on:` directive to listen to DOM events.
 
 <style>
 	div {
-		height: 100%;
+		height: 100vh;
 	}
 </style>
 ```


### PR DESCRIPTION
Changed the div styling from "height: 100%" to "height:100vh" to allow responsiveness on the whole screen
![Screenshot (6)](https://user-images.githubusercontent.com/70730188/178122629-8994c27f-35c0-4e53-9c9f-f211d6b394d1.png)

BEFORE

![Screenshot (5)](https://user-images.githubusercontent.com/70730188/178122633-70edcc86-cafb-41aa-8f9e-fbf03af7791d.png)
AFTER


With the cursor in the same position in the 2 photos, in the first picture, the cursor is not detected outside the 100 "%" height of the div but in the second one, the div's height has been made the complete height of the viewport.
