### PR TITLE
Changing url to id in a GET request

### DIFF
--- a/posts/sveltekit-for-beginners/sveltekit-for-beginners.md
+++ b/posts/sveltekit-for-beginners/sveltekit-for-beginners.md
@@ -2358,7 +2358,7 @@ import { timePosted } from '$root/utils/date'
 
 export const GET: RequestHandler = async ({ params }) => {
 	const tweet = await prisma.tweet.findFirst({
-		where: { url: params.tweetId },
+		where: { id: Number(params.tweetId) },
 		include: { user: true }
 	})
 


### PR DESCRIPTION
Is { url: params.tweetId } meant to be something like { id: Number(params.tweetId) } on line 2361 in this md file?
tweet.id lined up with the tweetId param I was getting in the url, and I wrapped it in Number() as ts was giving me a type error once i started using id.
With url i was getting an undefined error in the browser and from ts.

url: params.tweetId appears again on line 3171 in this md file, but I haven't changed that line as I haven't worked that far through yet to confirm if the amended code would be the correct there.