### PR TITLE
chore: fix typo - Proposed typo fix in the blog post

### DIFF
--- a/posts/sveltekit-authentication-using-cookies/sveltekit-authentication-using-cookies.md
+++ b/posts/sveltekit-authentication-using-cookies/sveltekit-authentication-using-cookies.md
@@ -551,9 +551,9 @@ The only thing you have to do is import the `enhance` action from SvelteKit and 
 </form>
 ```
 
-For the register page we need to rerun the `load` function for the page to update it.
+For the login page we need to rerun the `load` function for the page to update it.
 
-```html:register/+page.svelte showLineNumbers
+```html:login/+page.svelte showLineNumbers
 <script lang="ts">
   import { applyAction, enhance } from '$app/forms'
   import { invalidateAll } from '$app/navigation'


### PR DESCRIPTION
The blog post (I think mistakenly) says 'For the register page we need to rerun the `load` function for the page to update it.'

It should say 'For the login page we need to rerun the `load` function for the page to update it.'

The actual file being edited is the login +page.svelte file, but is listed as register/+page.svelte rather than login/+page.svelte, which I also changed. 

I guess it could be that the intent was to actually change the registration page to rerun instead, but it doesn't seem like that was the intention and I don't think the registration form works properly with a custom enhance function...

Sorry if this is stupid and I've just misread something. Your posts are always a pleasure to read/watch.