### PR TITLE
the user property can be null

### DIFF
--- a/posts/sveltekit-authentication-using-cookies/sveltekit-authentication-using-cookies.md
+++ b/posts/sveltekit-authentication-using-cookies/sveltekit-authentication-using-cookies.md
@@ -431,7 +431,7 @@ declare namespace App {
     user: {
       name: string
       role: string
-    }
+    }?
   }
 
   // interface PageData {}


### PR DESCRIPTION
In the hooks we don't enforce a locals.user property. For typescript projects this will hint to use optionnal chaining since user can be null