### PR TITLE
Update sveltekit-routing.md installation instructions

### DIFF
--- a/posts/sveltekit-routing/sveltekit-routing.md
+++ b/posts/sveltekit-routing/sveltekit-routing.md
@@ -27,7 +27,7 @@ I'm going to initialize a skeleton SvelteKit project with TypeScript but even if
 
 ```shell:terminal
 # create SvelteKit project
-npm create svelte
+npm create svelte@latest
 
 # install dependencies
 npm i


### PR DESCRIPTION
Change the installation instructions to read `npm create svelte@latest` rather than `npm create svelte`

Using npm create svelte would not install using npm install and it did not have all of the options available on setup.