### PR TITLE
refactor: Zero-effort type safety

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,8 +1,6 @@
-import type { PageServerLoad } from './$types'
-
 import { getPosts } from '$lib/api/posts'
 
-export const load: PageServerLoad = async ({ setHeaders }) => {
+export const load = async ({ setHeaders }) => {
 	const posts = await getPosts()
 
 	setHeaders({

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { ArrowNarrowRightIcon } from '@rgossiaux/svelte-heroicons/outline'
-	import type { PageServerData } from './$types'
 
 	import Newsletter from '$lib/shared/ui/newsletter.svelte'
 	import Posts from '$lib/shared/ui/posts.svelte'
@@ -15,7 +14,7 @@
 		twitterHandle,
 	} from '$lib/api/config'
 
-	export let data: PageServerData
+	export let data
 </script>
 
 <svelte:head>

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -1,8 +1,6 @@
-import type { PageServerLoad } from './$types'
-
 import { getPost } from '$lib/api/posts'
 
-export const load: PageServerLoad = async ({ params, setHeaders }) => {
+export const load = async ({ params, setHeaders }) => {
 	const { content, frontmatter } = await getPost(params.slug)
 
 	const day = 60 * 60 * 24 * 1000

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { browser, dev } from '$app/environment'
-	import type { PageServerData } from './$types'
 
 	import Card from './card.svelte'
 	import Clipboard from './clipboard.svelte'
@@ -16,7 +15,7 @@
 
 	import { updateViews } from '$lib/database'
 
-	export let data: PageServerData
+	export let data
 
 	let editUrl = `${fileUrl}/${data.frontmatter.slug}/${data.frontmatter.slug}.md`
 	let image = `${postImage}${encodeURIComponent(data.frontmatter.title)}.png`

--- a/src/routes/articles/+page.server.ts
+++ b/src/routes/articles/+page.server.ts
@@ -1,7 +1,6 @@
 import { getPosts } from '$lib/api/posts'
-import type { PageServerLoad } from './$types'
 
-export const load: PageServerLoad = async ({ setHeaders }) => {
+export const load = async ({ setHeaders }) => {
 	const { posts } = await getPosts()
 
 	setHeaders({

--- a/src/routes/articles/+page.svelte
+++ b/src/routes/articles/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import Heading from '$lib/shared/ui/heading.svelte'
 	import Posts from '$lib/shared/ui/posts.svelte'
-	import type { PageServerData } from './$types'
 
-	export let data: PageServerData
+	export let data
 </script>
 
 <svelte:head>

--- a/src/routes/categories/[category]/+page.server.ts
+++ b/src/routes/categories/[category]/+page.server.ts
@@ -1,11 +1,9 @@
 import { error } from '@sveltejs/kit'
-import type { PageServerLoad } from './$types'
 
 import { getPostsByCategory } from '$lib/api/posts'
-
 import { categories } from '$lib/api/config'
 
-export const load: PageServerLoad = async ({ params, setHeaders }) => {
+export const load = async ({ params, setHeaders }) => {
 	if (!categories[params.category]) {
 		throw error(404)
 	}

--- a/src/routes/categories/[category]/+page.svelte
+++ b/src/routes/categories/[category]/+page.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import { page } from '$app/stores'
-	import type { PageServerData } from './$types'
 
 	import Heading from '$lib/shared/ui/heading.svelte'
 	import Posts from '$lib/shared/ui/posts.svelte'
 
 	import { categories } from '$lib/api/config'
 
-	export let data: PageServerData
+	export let data
 
 	const category = $page.params.category
 </script>

--- a/src/routes/series/+page.server.ts
+++ b/src/routes/series/+page.server.ts
@@ -1,7 +1,6 @@
 import { getPosts } from '$lib/api/posts'
-import type { PageServerLoad } from './$types'
 
-export const load: PageServerLoad = async ({ setHeaders }) => {
+export const load = async ({ setHeaders }) => {
 	const { series } = await getPosts()
 
 	setHeaders({

--- a/src/routes/series/+page.svelte
+++ b/src/routes/series/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import Heading from '$lib/shared/ui/heading.svelte'
 	import Posts from '$lib/shared/ui/posts.svelte'
-	import type { PageServerData } from './$types'
 
-	export let data: PageServerData
+	export let data
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Type annotations are no longer required if you read [Zero-effort type safety](https://svelte.dev/blog/zero-config-type-safety).