### PR TITLE
Include a dispatch method

### DIFF
--- a/posts/animation-with-svelte/animation-with-svelte.md
+++ b/posts/animation-with-svelte/animation-with-svelte.md
@@ -485,8 +485,9 @@ I have a simple modal I want to spice up when a user opens it by scaling and tra
   }
 
   const dispatch = createEventDispatcher()
+  
   function closeModal() {
-		dispatch('close', {});
+		dispatch('close')
 	}
 </script>
 

--- a/posts/animation-with-svelte/animation-with-svelte.md
+++ b/posts/animation-with-svelte/animation-with-svelte.md
@@ -485,9 +485,12 @@ I have a simple modal I want to spice up when a user opens it by scaling and tra
   }
 
   const dispatch = createEventDispatcher()
+  function closeModal() {
+		dispatch('close', {});
+	}
 </script>
 
-<div class="modal-background" on:click={close} />
+<div class="modal-background" on:click={closeModal} />
 
 <div
   transition:modal={{ duration: 1000 }}


### PR DESCRIPTION
In my svelte version (3.54), not including a dispatch method resulted in an `illegal invocation` error.