### PR TITLE
Replace past icon with copy icon!

### DIFF
--- a/src/routes/[slug]/clipboard.svelte
+++ b/src/routes/[slug]/clipboard.svelte
@@ -13,23 +13,12 @@
 
 		copyBtnElement.forEach((btn) => {
 			btn.innerHTML = `
-        <span class="sr-only">Copy</span>
-        <svg
-          width="24"
-          height="24"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="2"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-            />
-        </svg>
-      `
+			<span class="sr-only">Copy</span>
+			<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" color="#000000">
+			  <path d="M19.4 20H9.6a.6.6 0 01-.6-.6V9.6a.6.6 0 01.6-.6h9.8a.6.6 0 01.6.6v9.8a.6.6 0 01-.6.6z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+			  <path d="M15 9V4.6a.6.6 0 00-.6-.6H4.6a.6.6 0 00-.6.6v9.8a.6.6 0 00.6.6H9" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+			</svg>      
+			`
 			btn.addEventListener('click', copyToClipboard)
 		})
 


### PR DESCRIPTION
Whenever I want to copy code from joyofcode, I'm confused by the pasting icon. I want to copy code out of the box, not paste into it! So I replaced the pasting icon with a copy icon instead.