### PR TITLE
open aside automatically only in 2xl screens

### DIFF
--- a/src/routes/[slug]/toc.svelte
+++ b/src/routes/[slug]/toc.svelte
@@ -30,7 +30,10 @@
 
 	onMount(() => {
 		getTableOfContents()
-		return openSidebar()
+		const isLargeScreen = window.innerWidth >= 1536
+		if (isLargeScreen) {
+			return openSidebar()
+		}
 	})
 
 	function toggleSidebar() {

--- a/src/routes/[slug]/toc.svelte
+++ b/src/routes/[slug]/toc.svelte
@@ -30,7 +30,9 @@
 
 	onMount(() => {
 		getTableOfContents()
-		const isLargeScreen = window.innerWidth >= 1536
+
+		const isLargeScreen = window.innerWidth >= 1440
+
 		if (isLargeScreen) {
 			return openSidebar()
 		}


### PR DESCRIPTION
Hi! Thanks for creating good content and open-sourcing your website!
This PR makes the aside open automatically only in 2xl size screens. This covers the main content when used in a mobile device. The arbitrary size 1536 is the same as tailwindcss 2xl size. 1280 (xl) will work here too - but it still covers some images. BTW - we can use the resolveConfig but it will increase the bundle unless using the babel plugin - so I hard-coded it. https://tailwindcss.com/docs/responsive-design. The arrow will be the same - but it won't open automatically

## Before

https://github.com/mattcroat/joy-of-code/assets/16452789/294fa7f1-5c02-41fe-b0b7-28487f2e47fc

## After

Hopefully it won't open automatically.

## Notice

I did not test it locally because I don't have the supabase key. Double check this PR.
