### PR TITLE
Update sveltekit-markdown-blog.md

### DIFF
--- a/posts/sveltekit-markdown-blog/sveltekit-markdown-blog.md
+++ b/posts/sveltekit-markdown-blog/sveltekit-markdown-blog.md
@@ -766,15 +766,19 @@ import { getHighlighter } from 'shiki'
 const mdsvexOptions = {
 	extensions: ['.md'],
 	highlight: {
-		const highlighter = await getHighlighter({
-			themes: ['poimandres'],
-			langs: ['javascript', 'typescript']
-		})
-		await highlighter.loadLanguage('javascript', 'typescript')
-		const html = escapeSvelte(highlighter.codeToHtml(code, { lang, theme: 'poimandres' }))
-		return `{@html \`${html}\` }`
+		highlighter: async (code, lang = 'text') => {
+			const highlighter = await getHighlighter({
+				theme: 'catppuccin-mocha',
+				langs: ['javascript', 'typescript']
+			});
+			await highlighter.loadTheme('catppuccin-mocha');
+
+			const html = escapeSvelte(
+				highlighter.codeToHtml(code, { lang, theme: 'catppuccin-mocha' })
+			);
+			return `{@html \`${html}\` }`;
 		}
-	},
+	}
 }
 
 // ...


### PR DESCRIPTION
Original syntax was most likely copied incorrectly - it was missing the highlighter key which has an async function inside that gives you the code and lang. This fix does it and adds the proper syntax highlighting!