### PR TITLE
fix: Border glitches on focused elements

### DIFF
--- a/src/routes/[slug]/toc.svelte
+++ b/src/routes/[slug]/toc.svelte
@@ -126,8 +126,4 @@
 		counter-increment: section;
 		content: counter(section) '. ';
 	}
-
-	:global(.table-of-contents a:focus) {
-		margin: 0;
-	}
 </style>

--- a/src/routes/[slug]/toc.svelte
+++ b/src/routes/[slug]/toc.svelte
@@ -83,7 +83,7 @@
 
 	.sidebar-toggle,
 	.table-of-contents {
-		padding: var(--spacing-24);
+		padding: var(--spacing-16);
 		background-color: var(--clr-bg);
 		border-top: 1px solid var(--clr-menu-border);
 		border-left: 1px solid var(--clr-menu-border);
@@ -105,12 +105,13 @@
 	}
 
 	:global(.table-of-contents ul) {
+		padding: var(--spacing-4) var(--spacing-8);
 		max-height: 400px;
 		overflow-y: scroll;
 	}
 
 	:global(.table-of-contents li) {
-		margin-top: var(--font-16);
+		margin-top: var(--spacing-8);
 		font-weight: 400;
 	}
 
@@ -124,5 +125,9 @@
 		all: unset;
 		counter-increment: section;
 		content: counter(section) '. ';
+	}
+
+	:global(.table-of-contents a:focus) {
+		margin: 0;
 	}
 </style>

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -6,7 +6,7 @@
 }
 
 .prose pre {
-	padding: var(--spacing-16) 0;
+	padding-bottom: var(--spacing-16);
 	line-height: 34px;
 	background-image: var(--clr-code-bg);
 	border-left: 1px solid var(--clr-code-border);
@@ -59,7 +59,7 @@ html[data-font='dyslexic'] .prose code {
 .prose .rehype-code-title {
 	display: flex;
 	justify-content: space-between;
-	padding: var(--spacing-16) var(--spacing-24) 0 var(--spacing-24);
+	padding: var(--spacing-16) var(--spacing-24);
 	font-size: var(--post-txt-size);
 	color: var(--clr-code-title);
 	background-color: var(--clr-code-title-bg);
@@ -68,6 +68,10 @@ html[data-font='dyslexic'] .prose code {
 	border-bottom: none;
 	border-top-left-radius: var(--rounded-20);
 	border-top-right-radius: var(--rounded-20);
+}
+
+.prose .copy > svg {
+	margin-bottom: 1px; // It balances the gap on top of icon (which causes visual asymmetry) caused by span.sr-only
 }
 
 .prose .line-number::before {

--- a/src/styles/code.scss
+++ b/src/styles/code.scss
@@ -70,10 +70,6 @@ html[data-font='dyslexic'] .prose code {
 	border-top-right-radius: var(--rounded-20);
 }
 
-.prose .copy > svg {
-	margin-bottom: 1px; // It balances the gap on top of icon (which causes visual asymmetry) caused by span.sr-only
-}
-
 .prose .line-number::before {
 	content: counter(step);
 	counter-increment: step;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -183,6 +183,11 @@ a:hover::before {
 	transform: scaleX(1);
 }
 
+a:focus {
+	padding: 0 var(--spacing-4);
+	margin: 0 var(--spacing-4);
+}
+
 table {
 	margin-bottom: var(--spacing-32);
 	border-collapse: collapse;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -183,11 +183,6 @@ a:hover::before {
 	transform: scaleX(1);
 }
 
-a:focus {
-	padding: 0 var(--spacing-4);
-	margin: 0 var(--spacing-4);
-}
-
 table {
 	margin-bottom: var(--spacing-32);
 	border-collapse: collapse;


### PR DESCRIPTION
- Fixed visual border glitches when an element is focused.
Before:
![before](https://github.com/mattcroat/joy-of-code/assets/155140399/4133e1a8-b6a6-467a-82b0-dede8a0700c2)

After:
![after](https://github.com/mattcroat/joy-of-code/assets/155140399/90a96a91-16be-421f-921e-50ed9bdfb0dd)

- Content shifts a very little when focused, after this change, but accessibility and other performances do not get affected.
![image](https://github.com/mattcroat/joy-of-code/assets/155140399/41d4b2aa-12f3-4c85-bd73-bf736079add3)