### PR TITLE
fix rss double slash

### DIFF
--- a/src/routes/rss.xml/+server.ts
+++ b/src/routes/rss.xml/+server.ts
@@ -24,8 +24,8 @@ export async function GET() {
 						<item>
 							<title>${post.title}</title>
 							<description>${post.description}</description>
-							<link>${config.siteUrl}/${post.slug}</link>
-							<guid isPermaLink="true">${config.siteUrl}/${post.slug}</guid>
+							<link>${config.siteUrl}${post.slug}</link>
+							<guid isPermaLink="true">${config.siteUrl}${post.slug}</guid>
 							<pubDate>${new Date(post.published).toUTCString()}</pubDate>
 						</item>
 					`


### PR DESCRIPTION
Current domain.com/rss.xml will have double slashes this is a simple fix. 

for reference check https://joyofcode.xyz/rss.xml