### PR TITLE
fix: add missing sign in front of state

### DIFF
--- a/posts/master-the-svelte-context-api/master-the-svelte-context-api.md
+++ b/posts/master-the-svelte-context-api/master-the-svelte-context-api.md
@@ -245,7 +245,7 @@ This is because it's going to use the value at the time it was created if we loo
 
 ```js
 // signal
-let banana = state('🍌')
+let banana = $state('🍌')
 // get the value of the signal
 setContext('key', get(banana))
 ```


### PR DESCRIPTION
Just noticed a missing dollar sign in front of a `$state()` statement.